### PR TITLE
DEV-2217 Update scikit-allel dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ pandas==0.25.0
 python-dateutil==2.8.0
 pytz==2019.2
 requests==2.22.0
-scikit-allel==1.2.1
+scikit-allel==1.3.5
+setuptools==40.6.2
 six==1.12.0
 toolz==0.10.0
 TransVar==2.5.8.20190813


### PR DESCRIPTION
The pipeline5 imager script recently stopped working with the version of
this dependency that was pinned in the requirements (==1.2.1). It wasn't
entirely clear what was happening but I believe there were conflicts
with some of the other versions specified in the requirements.txt.

I arrived at the new version by removing the version from the
requirements and reinstalling in a new virtual environment, essentially
allowing `pip` to select the new version. There may be better ways to do
this but I'm no expert and this at least allows the image to be built.
Of course further testing is required, either standalone or as part of
the pipeline 5.24 release.

I also added in the `setuptools` dependency that `pip` decided on as it
seems it was previously being added implicitly.